### PR TITLE
Fix link to bsmtrace repo

### DIFF
--- a/bsmtrace.page
+++ b/bsmtrace.page
@@ -41,7 +41,7 @@
     <html>
       <p>
       <span id="collection-label">GitHub:</span>
-      <a href="https://github.com/openbsm/openbsm">https://github.com/openbsm/bsmtrace</a>
+      <a href="https://github.com/openbsm/bsmtrace">https://github.com/openbsm/bsmtrace</a>
       </p>
 
       <p>BSMtrace is a utility that processes audit trails, or real-time


### PR DESCRIPTION
We are linking to openbsm and not bsmtrace here.